### PR TITLE
Recover dapp bridge after extension restart

### DIFF
--- a/content.js
+++ b/content.js
@@ -22,13 +22,17 @@
   const RECONNECT_DELAY_BASE = 1000; // 基础延迟 1 秒
   const QUEUE_MAX_AGE = 15000; // 请求排队超时
   const QUEUE_MAX_SIZE = 100; // 最大排队请求数
+  const bridgeToken =
+    `${chrome.runtime.id}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
 
   // ==================== 注入 inject.js ====================
 
   function injectScript() {
     const script = document.createElement('script');
     script.type = 'module';
-    script.src = chrome.runtime.getURL('inject.js');
+    const url = new URL(chrome.runtime.getURL('inject.js'));
+    url.searchParams.set('bridgeToken', bridgeToken);
+    script.src = url.toString();
     script.onload = function () {
       console.log('✅ inject.js loaded');
       this.remove();
@@ -158,8 +162,8 @@
 
     console.log('📬 Bridge received from background:', message);
 
-    // 直接转发到页面（不做任何处理）
-    window.postMessage(message, '*');
+    // 只把本 content bridge 处理过的请求响应回传给页面。
+    window.postMessage(withBridgeToken(message), '*');
   }
 
   function handlePageMessage(event) {
@@ -170,6 +174,10 @@
 
     // 只处理 YEYING_MESSAGE
     if (message?.type !== MESSAGE_TYPE) return;
+
+    if (message.metadata?.bridgeToken !== bridgeToken) {
+      return;
+    }
 
     console.log('📨 Bridge received from page:', message);
 
@@ -221,12 +229,22 @@
 
   function sendEventToPage(event, data) {
     const message = MessageBuilder.createEvent(event, data);
-    window.postMessage(message, '*');
+    window.postMessage(withBridgeToken(message), '*');
   }
 
   function sendErrorToPage(requestId, error) {
     const message = MessageBuilder.createErrorResponse(error, requestId);
-    window.postMessage(message, '*');
+    window.postMessage(withBridgeToken(message), '*');
+  }
+
+  function withBridgeToken(message) {
+    return {
+      ...message,
+      metadata: {
+        ...(message.metadata || {}),
+        bridgeToken
+      }
+    };
   }
 
   // ==================== 监听广播事件 ====================
@@ -238,7 +256,7 @@
 
     // 转发事件到页面
     if (message.category === MessageCategory.EVENT) {
-      window.postMessage(message, '*');
+      window.postMessage(withBridgeToken(message), '*');
       sendResponse({ success: true });
       return true; // 保持消息通道开启
     }

--- a/content.js
+++ b/content.js
@@ -24,6 +24,15 @@
   const QUEUE_MAX_SIZE = 100; // 最大排队请求数
   const bridgeToken =
     `${chrome.runtime.id}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+  const previousBridge = globalThis.__YEYING_WALLET_CONTENT_BRIDGE__;
+  if (previousBridge && typeof previousBridge.dispose === 'function') {
+    previousBridge.dispose('content_script_reinject');
+  }
+  const bridgeState = {
+    disposed: false,
+    dispose: null
+  };
+  globalThis.__YEYING_WALLET_CONTENT_BRIDGE__ = bridgeState;
 
   // ==================== 注入 inject.js ====================
 
@@ -53,6 +62,7 @@
   const requestQueue = new Map();
 
   function initConnection() {
+    if (bridgeState.disposed) return;
     // 检查扩展上下文是否有效
     if (!chrome.runtime?.id) {
       console.error('❌ Extension context invalidated');
@@ -94,6 +104,7 @@
   }
 
   function handleDisconnect() {
+    if (bridgeState.disposed) return;
     console.warn('⚠️ Port disconnected');
 
     const error = chrome.runtime.lastError;
@@ -128,6 +139,7 @@
   }
 
   function flushQueuedRequests() {
+    if (bridgeState.disposed) return;
     if (!port || requestQueue.size === 0) return;
 
     const now = Date.now();
@@ -158,6 +170,7 @@
   // ==================== 消息处理 ====================
 
   function handleBackgroundMessage(message) {
+    if (bridgeState.disposed) return;
     if (message?.type !== MESSAGE_TYPE) return;
 
     console.log('📬 Bridge received from background:', message);
@@ -167,6 +180,7 @@
   }
 
   function handlePageMessage(event) {
+    if (bridgeState.disposed) return;
     // 只处理来自当前页面的消息
     if (event.source !== window) return;
 
@@ -250,6 +264,7 @@
   // ==================== 监听广播事件 ====================
 
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (bridgeState.disposed) return;
     if (message?.type !== MESSAGE_TYPE) return;
 
     console.log('📬 Content script received broadcast:', message);
@@ -263,6 +278,22 @@
   });
 
   // ==================== 启动 ====================
+
+  bridgeState.dispose = function disposeBridge(reason) {
+    if (bridgeState.disposed) return;
+    bridgeState.disposed = true;
+    window.removeEventListener('message', handlePageMessage);
+    requestQueue.clear();
+    if (port) {
+      try {
+        port.disconnect();
+      } catch (error) {
+        // Ignore disconnect errors while replacing the content bridge.
+      }
+      port = null;
+    }
+    console.log('🧹 Content script bridge disposed:', reason);
+  };
 
   window.addEventListener('message', handlePageMessage);
   initConnection();

--- a/inject.js
+++ b/inject.js
@@ -19,7 +19,7 @@ const INJECT_SCRIPT_URL = import.meta.url;
 
   console.log('🔌 YeYing Wallet Provider initializing...');
 
-  const BRIDGE_TOKEN = (() => {
+  const INITIAL_BRIDGE_TOKEN = (() => {
     try {
       const src = INJECT_SCRIPT_URL || '';
       if (!src) return '';
@@ -29,16 +29,13 @@ const INJECT_SCRIPT_URL = import.meta.url;
     }
   })();
 
-  if (!BRIDGE_TOKEN) {
+  if (!INITIAL_BRIDGE_TOKEN) {
     console.error('❌ YeYing bridge token missing, provider injection aborted');
     return;
   }
 
-  // ==================== 防止重复注入 ====================
-  if (window.ethereum && window.ethereum.isYeYing) {
-    console.warn('⚠️ YeYing Provider already injected');
-    return;
-  }
+  const existingProvider =
+    window.ethereum && window.ethereum.isYeYing ? window.ethereum : null;
 
   // ==================== 协议常量 ====================
 
@@ -155,6 +152,7 @@ const INJECT_SCRIPT_URL = import.meta.url;
 
       // 待处理的请求
       this._pendingRequests = new Map();
+      this._bridgeToken = INITIAL_BRIDGE_TOKEN;
 
       // 初始化
       this._initialize();
@@ -182,7 +180,7 @@ const INJECT_SCRIPT_URL = import.meta.url;
 
       // 只处理 YEYING_MESSAGE
       if (message?.type !== MESSAGE_TYPE) return;
-      if (message.metadata?.bridgeToken !== BRIDGE_TOKEN) return;
+      if (message.metadata?.bridgeToken !== this._bridgeToken) return;
 
       console.log('📥 Provider received:', message);
 
@@ -357,7 +355,7 @@ const INJECT_SCRIPT_URL = import.meta.url;
     async _sendRequest(method, params) {
       return new Promise((resolve, reject) => {
         const message = MessageBuilder.createRequest(method, params, window.location.origin);
-        message.metadata.bridgeToken = BRIDGE_TOKEN;
+        message.metadata.bridgeToken = this._bridgeToken;
         const requestId = message.metadata.id;
 
         // 设置超时
@@ -378,11 +376,43 @@ const INJECT_SCRIPT_URL = import.meta.url;
           reject,
           timeoutId,
           method,
+          message,
           timestamp: Date.now()
         });
 
         // 发送消息到 content script
         window.postMessage(message, '*');
+      });
+    }
+
+    _setBridgeToken(bridgeToken) {
+      if (!bridgeToken || bridgeToken === this._bridgeToken) return;
+
+      console.log('🔄 Rebinding YeYing Provider bridge');
+      this._bridgeToken = bridgeToken;
+      this._replayPendingRequests();
+      this._state.isConnected = false;
+      this._connectEmitted = false;
+      this._requestInitialState();
+    }
+
+    _rejectPendingRequests(code, message) {
+      this._pendingRequests.forEach((pending) => {
+        clearTimeout(pending.timeoutId);
+        pending.reject(new ProviderRpcError(code, message));
+      });
+      this._pendingRequests.clear();
+    }
+
+    _replayPendingRequests() {
+      this._pendingRequests.forEach((pending, requestId) => {
+        if (!pending.message) {
+          return;
+        }
+        pending.message.metadata.bridgeToken = this._bridgeToken;
+        pending.timestamp = Date.now();
+        console.log('🔁 Replaying pending wallet request:', pending.method, requestId);
+        window.postMessage(pending.message, '*');
       });
     }
 
@@ -500,7 +530,90 @@ const INJECT_SCRIPT_URL = import.meta.url;
     }
   }
 
+  function rebindExistingProvider(provider, bridgeToken) {
+    console.warn('⚠️ YeYing Provider already injected, rebinding bridge');
+
+    if (provider._yeyingBridgeMessageListener) {
+      window.removeEventListener('message', provider._yeyingBridgeMessageListener);
+    }
+
+    provider._yeyingBridgeMessageListener = (event) => {
+      if (event.source !== window) return;
+
+      const message = event.data;
+      if (message?.type !== MESSAGE_TYPE) return;
+      if (message.metadata?.bridgeToken !== provider._bridgeToken) return;
+
+      const { category } = message;
+      if (category === MessageCategory.RESPONSE) {
+        provider._handleResponse(message);
+      } else if (category === MessageCategory.EVENT) {
+        provider._handleEvent(message);
+      }
+    };
+    window.addEventListener('message', provider._yeyingBridgeMessageListener);
+
+    provider._replayPendingRequests = function () {
+      this._pendingRequests?.forEach((pending, requestId) => {
+        if (!pending.message) return;
+        pending.message.metadata.bridgeToken = this._bridgeToken;
+        pending.timestamp = Date.now();
+        console.log('🔁 Replaying pending wallet request:', pending.method, requestId);
+        window.postMessage(pending.message, '*');
+      });
+    };
+
+    provider._setBridgeToken = function (nextBridgeToken) {
+      if (!nextBridgeToken || nextBridgeToken === this._bridgeToken) return;
+
+      console.log('🔄 Rebinding YeYing Provider bridge');
+      this._bridgeToken = nextBridgeToken;
+      this._replayPendingRequests?.();
+      this._state.isConnected = false;
+      this._connectEmitted = false;
+      this._requestInitialState?.();
+    };
+
+    provider._sendRequest = function (method, params) {
+      return new Promise((resolve, reject) => {
+        const message = MessageBuilder.createRequest(method, params, window.location.origin);
+        message.metadata.bridgeToken = this._bridgeToken;
+        const requestId = message.metadata.id;
+
+        const timeoutId = setTimeout(() => {
+          this._pendingRequests.delete(requestId);
+          reject(
+            new ProviderRpcError(
+              -32603,
+              'Request timeout',
+              { method, timeout: REQUEST_TIMEOUT }
+            )
+          );
+        }, REQUEST_TIMEOUT);
+
+        this._pendingRequests.set(requestId, {
+          resolve,
+          reject,
+          timeoutId,
+          method,
+          message,
+          timestamp: Date.now()
+        });
+
+        window.postMessage(message, '*');
+      });
+    };
+
+    provider._setBridgeToken(bridgeToken);
+    window.dispatchEvent(new Event('ethereum#initialized'));
+  }
+
   // ==================== 注入到 window ====================
+
+  if (existingProvider) {
+    rebindExistingProvider(existingProvider, INITIAL_BRIDGE_TOKEN);
+    return;
+  }
 
   const provider = new YeYingProvider();
 

--- a/inject.js
+++ b/inject.js
@@ -12,10 +12,27 @@ import {
   MessageBuilder
 } from './js/protocol/dapp-protocol.js';
 
+const INJECT_SCRIPT_URL = import.meta.url;
+
 (function () {
   'use strict';
 
   console.log('🔌 YeYing Wallet Provider initializing...');
+
+  const BRIDGE_TOKEN = (() => {
+    try {
+      const src = INJECT_SCRIPT_URL || '';
+      if (!src) return '';
+      return new URL(src).searchParams.get('bridgeToken') || '';
+    } catch (error) {
+      return '';
+    }
+  })();
+
+  if (!BRIDGE_TOKEN) {
+    console.error('❌ YeYing bridge token missing, provider injection aborted');
+    return;
+  }
 
   // ==================== 防止重复注入 ====================
   if (window.ethereum && window.ethereum.isYeYing) {
@@ -165,6 +182,7 @@ import {
 
       // 只处理 YEYING_MESSAGE
       if (message?.type !== MESSAGE_TYPE) return;
+      if (message.metadata?.bridgeToken !== BRIDGE_TOKEN) return;
 
       console.log('📥 Provider received:', message);
 
@@ -339,6 +357,7 @@ import {
     async _sendRequest(method, params) {
       return new Promise((resolve, reject) => {
         const message = MessageBuilder.createRequest(method, params, window.location.origin);
+        message.metadata.bridgeToken = BRIDGE_TOKEN;
         const requestId = message.metadata.id;
 
         // 设置超时

--- a/js/background/index.js
+++ b/js/background/index.js
@@ -14,6 +14,11 @@ import { normalizePopupBounds } from './window-utils.js';
 import { backupSyncService } from './sync-service.js';
 import { mpcService } from './mpc-service.js';
 
+const INJECTABLE_TAB_URLS = [
+  'http://*/*',
+  'https://*/*'
+];
+
 /**
  * 初始化 Background Script
  */
@@ -71,7 +76,42 @@ async function init() {
 }
 
 // 启动
-init();
+init()
+  .then(() => reinjectContentScripts('background_init'))
+  .catch((error) => {
+    console.warn('⚠️ Background init finished with reinjection skipped:', error);
+  });
+
+async function reinjectContentScripts(reason) {
+  if (!chrome.scripting?.executeScript) {
+    console.warn('⚠️ chrome.scripting API unavailable, skip content reinjection');
+    return;
+  }
+
+  let tabs = [];
+  try {
+    tabs = await chrome.tabs.query({ url: INJECTABLE_TAB_URLS });
+  } catch (error) {
+    console.warn('⚠️ Failed to query tabs for content reinjection:', error);
+    return;
+  }
+
+  await Promise.all(
+    tabs.map(async (tab) => {
+      if (!tab.id || !tab.url) return;
+
+      try {
+        await chrome.scripting.executeScript({
+          target: { tabId: tab.id, allFrames: false },
+          files: ['content.js']
+        });
+        console.log('✅ Re-injected content script:', reason, tab.id, tab.url);
+      } catch (error) {
+        console.warn('⚠️ Failed to re-inject content script:', tab.id, tab.url, error);
+      }
+    })
+  );
+}
 
 // 监听扩展安装/更新
 chrome.runtime.onInstalled.addListener((details) => {
@@ -83,4 +123,13 @@ chrome.runtime.onInstalled.addListener((details) => {
   } else if (details.reason === 'update') {
     console.log('🔄 Extension updated');
   }
+
+  if (details.reason === 'install' || details.reason === 'update') {
+    reinjectContentScripts(details.reason);
+  }
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  console.log('🚀 Extension startup, checking existing tabs');
+  reinjectContentScripts('startup');
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,13 @@
 {
   "manifest_version": 3,
   "name": "夜莺钱包",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "description": "夜莺钱包插件",
   "permissions": [
     "storage",
     "activeTab",
     "tabs",
+    "scripting",
     "offscreen"
   ],
   "host_permissions": [


### PR DESCRIPTION
## Summary
- scope dapp bridge messages to the provider instance
- reinject content scripts into existing tabs after extension startup/install/update
- rebind existing page providers to the new bridge token after extension restart
- dispose stale content bridges and replay pending requests instead of surfacing reconnect errors

## Verification
- node --check inject.js && node --check content.js && node --check js/background/index.js
- node --experimental-vm-modules scripts/test-approval-flow.mjs