### PR TITLE
Add Ethereum token transfers and fee estimates

### DIFF
--- a/css/wallet.css
+++ b/css/wallet.css
@@ -63,6 +63,26 @@ body {
   padding: 12px 20px 20px;
 }
 
+.transfer-fee-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 38px;
+  padding: 10px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #f9fafb;
+  color: #4b5563;
+  font-size: 13px;
+}
+
+#transferFeeEstimate {
+  color: #111827;
+  font-weight: 600;
+  text-align: right;
+}
+
 /* ========== 创建钱包页面布局（中间可滚动） ========== */
 #setPasswordPage {
   padding: 0;

--- a/html/popup.html
+++ b/html/popup.html
@@ -394,6 +394,10 @@
             />
             <span id="transferMaxHint" class="form-hint"></span>
           </div>
+          <div class="transfer-fee-row">
+            <span>预计手续费</span>
+            <span id="transferFeeEstimate">-</span>
+          </div>
         </div>
         <div class="transfer-footer">
           <button class="btn btn-primary btn-block" id="sendBtn">发送</button>

--- a/js/background/message-handler.js
+++ b/js/background/message-handler.js
@@ -352,6 +352,121 @@ async function handleSendTransactionMessage(data) {
   }
 }
 
+async function handleEstimateGasMessage(data) {
+  const { from, to, value, data: txData, gas, gasLimit, chainId, rpcUrl } = data || {};
+  if (!from || !to) {
+    return { success: false, error: 'Invalid transaction params' };
+  }
+
+  try {
+    const estimateRpcUrl = await resolveTransactionRpcUrl({ chainId, rpcUrl });
+    const tx = {
+      from,
+      to,
+      value: value || '0x0',
+      data: txData || '0x'
+    };
+    const limit = gasLimit || gas;
+    if (limit) {
+      tx.gas = limit;
+    }
+    const gasEstimate = await callJsonRpc(estimateRpcUrl, 'eth_estimateGas', [tx]);
+    return { success: true, gas: gasEstimate };
+  } catch (error) {
+    return { success: false, error: normalizeRpcUiError(error, 'Estimate gas failed') };
+  }
+}
+
+async function handleGetGasPriceMessage(data = {}) {
+  try {
+    const { chainId, rpcUrl } = data || {};
+    const gasRpcUrl = await resolveTransactionRpcUrl({ chainId, rpcUrl });
+    const gasPrice = await callJsonRpc(gasRpcUrl, 'eth_gasPrice', []);
+    return { success: true, gasPrice };
+  } catch (error) {
+    return { success: false, error: normalizeRpcUiError(error, 'Failed to get gas price') };
+  }
+}
+
+async function resolveTransactionRpcUrl({ chainId = null, rpcUrl = null } = {}) {
+  if (rpcUrl) {
+    return rpcUrl;
+  }
+
+  if (chainId) {
+    const network = await getStoredNetworkByChainId(chainId);
+    const networkRpcUrl = network?.rpcUrl || network?.rpc;
+    if (networkRpcUrl) {
+      return networkRpcUrl;
+    }
+  }
+
+  const resolvedRpcUrl = await resolveRpcUrl();
+  if (!resolvedRpcUrl) {
+    throw new Error('RPC URL not configured');
+  }
+  return resolvedRpcUrl;
+}
+
+async function callJsonRpc(rpcUrl, method, params) {
+  if (!rpcUrl) {
+    throw new Error('RPC URL not configured');
+  }
+
+  const response = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: getTimestamp(),
+      method,
+      params
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const payload = await response.json();
+  if (payload.error) {
+    throw new Error(payload.error.message || 'RPC error');
+  }
+
+  return payload.result;
+}
+
+function normalizeRpcUiError(error, fallbackMessage) {
+  const rawMessage = String(error?.reason || error?.shortMessage || error?.message || error || fallbackMessage || '').trim();
+  const reason = extractRpcRevertReason(rawMessage);
+  const message = reason || rawMessage || fallbackMessage;
+  return truncateRpcUiError(message);
+}
+
+function extractRpcRevertReason(message) {
+  if (!message) return '';
+  const reasonMatch = message.match(/reason="([^"]+)"/);
+  if (reasonMatch?.[1]) return reasonMatch[1];
+  const revertedQuotedMatch = message.match(/execution reverted:\s*"([^"]+)"/i);
+  if (revertedQuotedMatch?.[1]) return revertedQuotedMatch[1];
+  const revertedTextMatch = message.match(/execution reverted:?\s*([^(]+)?/i);
+  if (revertedTextMatch?.[1]) return revertedTextMatch[1].trim();
+  const argsMatch = message.match(/"args":\s*\[\s*"([^"]+)"/);
+  if (argsMatch?.[1]) return argsMatch[1];
+  return '';
+}
+
+function truncateRpcUiError(message) {
+  const cleaned = String(message || '')
+    .replace(/\s*\(action=.*$/i, '')
+    .replace(/\s*\{.*$/s, '')
+    .trim();
+  if (!cleaned) {
+    return 'RPC error';
+  }
+  return cleaned.length > 120 ? `${cleaned.slice(0, 120)}...` : cleaned;
+}
+
 async function resolveRpcUrl(chainIdOverride = null) {
   const targetChainId = chainIdOverride || state.currentChainId;
   let rpcUrl = state.currentRpcUrl;
@@ -901,6 +1016,14 @@ export async function handlePopupMessage(message, response) {
 
       case TransactionMessageType.SEND_TRANSACTION:
         response(await handleSendTransactionMessage(data));
+        break;
+
+      case TransactionMessageType.ESTIMATE_GAS:
+        response(await handleEstimateGasMessage(data));
+        break;
+
+      case TransactionMessageType.GET_GAS_PRICE:
+        response(await handleGetGasPriceMessage(data));
         break;
 
       case TransactionMessageType.GET_TRANSACTIONS:

--- a/js/background/message-handler.js
+++ b/js/background/message-handler.js
@@ -302,7 +302,7 @@ async function resolveAccountIdByAddress(address) {
 }
 
 async function handleSendTransactionMessage(data) {
-  const { from, to, value, data: txData, gas, gasLimit, chainId } = data || {};
+  const { from, to, value, data: txData, gas, gasLimit, chainId, token } = data || {};
   if (!from || !to || !value) {
     return { success: false, error: 'Invalid transaction params' };
   }
@@ -338,6 +338,7 @@ async function handleSendTransactionMessage(data) {
       from,
       to,
       value: result?.value ?? value,
+      token: token || null,
       timestamp: getTimestamp(),
       status: 'pending',
       chainId: normalizedChainId || state.currentChainId || null

--- a/js/background/wallet-operations.js
+++ b/js/background/wallet-operations.js
@@ -59,7 +59,7 @@ import { getCachedPassword, cachePassword, refreshPasswordCache, clearPasswordCa
 import { resetLockTimer, lockWallet } from './keyring.js';
 import { normalizeChainId } from '../common/chain/index.js';
 import { broadcastEvent, sendEvent } from './connection.js';
-import { TIMEOUTS, LIMITS, NETWORKS, DEFAULT_NETWORK, isDeveloperFeatureEnabled } from '../config/index.js';
+import { TIMEOUTS, LIMITS, NETWORKS, DEFAULT_NETWORK, BUILTIN_TOKENS_BY_CHAIN_ID, isDeveloperFeatureEnabled } from '../config/index.js';
 import { notifyUnlocked } from './unlock-flow.js';
 import { updateKeepAlive } from './offscreen.js';
 import { getTimestamp } from '../common/utils/time-utils.js';
@@ -69,6 +69,30 @@ import { mpcService } from './mpc-service.js';
 
 const CUSTOM_TOKENS_KEY = 'custom_tokens';
 const MIN_PASSWORD_LENGTH = 8;
+
+function getCurrentTokenChainId() {
+  const chainId = state.currentChainId || '0x1';
+  try {
+    return normalizeChainId(chainId);
+  } catch {
+    return chainId;
+  }
+}
+
+function mergeTokenLists(builtinTokens, customTokens) {
+  const byAddress = new Map();
+  [...(builtinTokens || []), ...(customTokens || [])].forEach((token) => {
+    const address = token?.address?.toLowerCase();
+    if (!address) return;
+    const previous = byAddress.get(address) || {};
+    byAddress.set(address, {
+      ...previous,
+      ...token,
+      address
+    });
+  });
+  return Array.from(byAddress.values());
+}
 
 /**
  * 检查钱包是否已初始化
@@ -708,7 +732,7 @@ export async function handleAddToken(token) {
     return { success: false, error: validation.errors?.[0] || 'invalid token' };
   }
 
-  const chainId = token.chainId || state.currentChainId || '0x1';
+  const chainId = token.chainId || getCurrentTokenChainId();
   const normalizedAddress = token.address.toLowerCase();
   const decimals = Number.isFinite(token.decimals)
     ? token.decimals
@@ -761,11 +785,15 @@ export async function handleGetTokenBalances(address) {
     return { success: false, error: addressValidation.error || 'invalid address' };
   }
 
-  const chainId = state.currentChainId || '0x1';
+  const chainId = getCurrentTokenChainId();
 
   try {
     const allTokens = await getUserSetting(CUSTOM_TOKENS_KEY, {});
-    const tokens = Array.isArray(allTokens[chainId]) ? allTokens[chainId] : [];
+    const customTokens = Array.isArray(allTokens[chainId]) ? allTokens[chainId] : [];
+    const builtinTokens = Array.isArray(BUILTIN_TOKENS_BY_CHAIN_ID[chainId])
+      ? BUILTIN_TOKENS_BY_CHAIN_ID[chainId]
+      : [];
+    const tokens = mergeTokenLists(builtinTokens, customTokens);
 
     if (tokens.length === 0) {
       return { success: true, tokens: [] };

--- a/js/config/index.js
+++ b/js/config/index.js
@@ -21,6 +21,7 @@ export {
 export {
   DEFAULT_NETWORK,
   NETWORKS,
+  BUILTIN_TOKENS_BY_CHAIN_ID,
   NETWORK_TYPES,
   RPC_CONFIG,
   getNetworkConfig,
@@ -147,4 +148,3 @@ export {
   validateUrl,
   validateNumberRange
 } from './validation-rules.js';
-

--- a/js/config/network-config.js
+++ b/js/config/network-config.js
@@ -24,7 +24,47 @@ export const NETWORKS = {
       symbol: 'YYT',
       decimals: 18
     }
+  },
+  ethereum: {
+    id: 'ethereum',
+    name: 'Ethereum Mainnet',
+    rpc: 'https://ethereum-rpc.publicnode.com',
+    rpcUrl: 'https://ethereum-rpc.publicnode.com',
+    chainId: 1,
+    chainIdHex: '0x1',
+    symbol: 'ETH',
+    decimals: 18,
+    explorer: 'https://etherscan.io',
+    type: 'mainnet',
+    isTestnet: false,
+    nativeCurrency: {
+      name: 'Ether',
+      symbol: 'ETH',
+      decimals: 18
+    }
   }
+};
+
+// ==================== 内置通证配置 ====================
+export const BUILTIN_TOKENS_BY_CHAIN_ID = {
+  '0x1': [
+    {
+      address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      symbol: 'USDC',
+      name: 'USD Coin',
+      decimals: 6,
+      chainId: '0x1',
+      builtin: true
+    },
+    {
+      address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+      symbol: 'USDT',
+      name: 'Tether USD',
+      decimals: 6,
+      chainId: '0x1',
+      builtin: true
+    }
+  ]
 };
 
 // ==================== 网络类型 ====================

--- a/js/controller/popup-controller.js
+++ b/js/controller/popup-controller.js
@@ -771,13 +771,10 @@ export class PopupController {
     if (sendBtn) {
       sendBtn.addEventListener('click', async () => {
         const selectedToken = this.tokensListController?.getCurrentTransferToken?.();
-        if (selectedToken && !selectedToken.isNative) {
-          showError('暂不支持通证转账');
-          return;
-        }
         await this.transactionSendController.handleSendTransaction({
           requestPassword: () => this.promptWalletPassword(),
           silentBalanceRefresh: true,
+          token: selectedToken || null,
           onSuccess: async () => {
             showPage('walletPage');
             this.switchWalletTab('activity');

--- a/js/controller/popup-controller.js
+++ b/js/controller/popup-controller.js
@@ -84,6 +84,9 @@ export class PopupController {
       onNetworkChanged: () => this.handleNetworkChanged()
     });
     this.tokensListController.setNetworkController(this.networkController);
+    this.tokensListController.setTransferTokenChangedHandler((token) => {
+      this.transactionSendController.scheduleFeeEstimate(token);
+    });
     this.addTokenController.setNetworkController(this.networkController);
     this.accountsListController = null;
     this.accountDetailController = new AccountDetailController({
@@ -611,6 +614,10 @@ export class PopupController {
     showPage('transferPage');
     await this.tokensListController?.prepareTransferSelectors?.();
     await this.contactsController?.loadContacts?.();
+    this.transactionSendController.setFeeEstimateText('-');
+    this.transactionSendController.scheduleFeeEstimate(
+      this.tokensListController?.getCurrentTransferToken?.() || null
+    );
   }
 
   async lockWallet() {
@@ -707,6 +714,22 @@ export class PopupController {
         this.closeWalletHeaderMenu();
         await this.openTransferPage();
       });
+    }
+
+    const updateTransferFee = () => {
+      this.transactionSendController.scheduleFeeEstimate(
+        this.tokensListController?.getCurrentTransferToken?.() || null
+      );
+    };
+    const recipientInput = document.getElementById('recipientAddress');
+    if (recipientInput && !recipientInput.dataset.feeEstimateBound) {
+      recipientInput.dataset.feeEstimateBound = '1';
+      recipientInput.addEventListener('input', updateTransferFee);
+    }
+    const amountInput = document.getElementById('amount');
+    if (amountInput && !amountInput.dataset.feeEstimateBound) {
+      amountInput.dataset.feeEstimateBound = '1';
+      amountInput.addEventListener('input', updateTransferFee);
     }
 
     const walletHeaderMenuBtn = document.getElementById('walletHeaderMenuBtn');

--- a/js/controller/tokens/tokens-list-controller.js
+++ b/js/controller/tokens/tokens-list-controller.js
@@ -27,6 +27,10 @@ export class TokensListController {
     return this.transferController.getCurrentTransferToken();
   }
 
+  setTransferTokenChangedHandler(handler) {
+    this.transferController.setTokenChangedHandler(handler);
+  }
+
   async loadTokenBalances() {
     try {
       if (!this.wallet || !this.token) {

--- a/js/controller/tokens/transfer-token-controller.js
+++ b/js/controller/tokens/transfer-token-controller.js
@@ -2,6 +2,7 @@ export class TransferTokenController {
   constructor({ wallet, networkController } = {}) {
     this.wallet = wallet;
     this.networkController = networkController || null;
+    this.onTokenChanged = null;
     this.transferTokenMap = new Map();
     this.currentTransferToken = null;
     this.boundTokenDocClick = false;
@@ -9,6 +10,10 @@ export class TransferTokenController {
 
   setNetworkController(controller) {
     this.networkController = controller;
+  }
+
+  setTokenChangedHandler(handler) {
+    this.onTokenChanged = typeof handler === 'function' ? handler : null;
   }
 
   bindEvents() {
@@ -198,5 +203,6 @@ export class TransferTokenController {
       : (token?.symbol || '原生代币');
     labelEl.dataset.value = selectedId;
     this.updateTransferTokenSelection();
+    this.onTokenChanged?.(token || null);
   }
 }

--- a/js/controller/transaction/transaction-detail-controller.js
+++ b/js/controller/transaction/transaction-detail-controller.js
@@ -40,12 +40,13 @@ export class TransactionDetailController {
 
     this.setDetailValueWithTitle('txDetailHash', formatTxHash(tx?.hash || ''), tx?.hash || '');
     this.setDetailValueWithTitle('txDetailFrom', shortenAddress(tx?.from || ''), tx?.from || '');
-    this.setDetailValueWithTitle('txDetailTo', shortenAddress(tx?.to || ''), tx?.to || '');
+    const displayTo = tx?.token?.recipient || tx?.to || '';
+    this.setDetailValueWithTitle('txDetailTo', shortenAddress(displayTo), displayTo);
 
     const networkMeta = await this.getNetworkMeta(tx?.chainId);
     const symbol = networkMeta?.symbol || await this.getCurrentNetworkSymbol();
-    const amount = this.transaction?.formatEther?.(tx?.value || '0') || '0';
-    this.setDetailValue('txDetailValue', `${amount} ${symbol}`);
+    const amountInfo = this.formatTransactionAmount(tx, symbol);
+    this.setDetailValue('txDetailValue', amountInfo);
 
     const timeValue = tx?.timestamp ? tx.timestamp : getTimestamp();
     this.setDetailValue('txDetailTime', formatLocaleDateTime(timeValue));
@@ -104,6 +105,17 @@ export class TransactionDetailController {
     const row = document.getElementById(id);
     if (!row) return;
     row.classList.toggle('hidden', !show);
+  }
+
+  formatTransactionAmount(tx, nativeSymbol) {
+    const token = tx?.token || null;
+    if (token?.amount) {
+      const decimals = Number.isFinite(Number(token.decimals)) ? Number(token.decimals) : 18;
+      const amount = this.transaction?.formatUnits?.(token.amount, decimals) || '0';
+      return `${amount} ${token.symbol || 'TOKEN'}`;
+    }
+    const amount = this.transaction?.formatEther?.(tx?.value || '0') || '0';
+    return `${amount} ${nativeSymbol}`;
   }
 
   bindDetailActions() {

--- a/js/controller/transaction/transaction-list-controller.js
+++ b/js/controller/transaction/transaction-list-controller.js
@@ -73,8 +73,9 @@ export class TransactionListController {
         const isSent = normalizedCurrent
           ? from.toLowerCase() === normalizedCurrent
           : Boolean(tx?.hash);
-        const counterparty = isSent ? to : from;
-        const amountText = this.transaction.formatTransactionValue(tx?.value || '0', isSent);
+        const token = tx?.token || null;
+        const counterparty = token?.recipient || (isSent ? to : from);
+        const amountText = this.formatTransactionAmount(tx, isSent);
         const statusText = this.transaction.getStatusText(tx?.status || 'pending');
         const timeValue = tx?.timestamp ? tx.timestamp : getTimestamp();
         return `
@@ -102,6 +103,17 @@ export class TransactionListController {
     });
 
     container.scrollTop = previousScrollTop;
+  }
+
+  formatTransactionAmount(tx, isSent) {
+    const token = tx?.token || null;
+    if (token?.amount) {
+      const decimals = Number.isFinite(Number(token.decimals)) ? Number(token.decimals) : 18;
+      const value = this.transaction?.formatUnits?.(token.amount, decimals) || '0';
+      const prefix = isSent ? '-' : '+';
+      return `${prefix}${value} ${token.symbol || 'TOKEN'}`;
+    }
+    return this.transaction.formatTransactionValue(tx?.value || '0', isSent);
   }
 
   openTransactionDetail(txHash) {

--- a/js/controller/transaction/transaction-send-controller.js
+++ b/js/controller/transaction/transaction-send-controller.js
@@ -2,6 +2,8 @@ import { isValidAddress } from '../../common/chain/index.js';
 import { showError, showWaiting, hideToast, hideWaiting } from '../../common/ui/index.js';
 import { isWalletLockedError } from '../../common/errors/index.js';
 
+const ERC20_TRANSFER_SELECTOR = '0xa9059cbb';
+
 export class TransactionSendController {
   constructor({ wallet, transaction, network, balanceController, transactionListController } = {}) {
     this.wallet = wallet;
@@ -19,7 +21,7 @@ export class TransactionSendController {
     this.transactionListController = controller;
   }
 
-  async handleSendTransaction({ requestPassword, onSuccess, silentBalanceRefresh = false } = {}) {
+  async handleSendTransaction({ requestPassword, onSuccess, silentBalanceRefresh = false, token = null } = {}) {
     const recipientInput = document.getElementById('recipientAddress');
     const amountInput = document.getElementById('amount');
 
@@ -51,14 +53,16 @@ export class TransactionSendController {
 
       const chainId = await this.network.getChainId();
       const rpcUrl = await this.network.getRpcUrl();
-
-      const txHash = await this.transaction.sendTransaction({
+      const txParams = this.buildTransactionParams({
         from: account.address,
-        to: recipient,
-        value: this.transaction.parseEther(amount),
-        chainId: chainId,
-        rpcUrl: rpcUrl
+        recipient,
+        amount,
+        chainId,
+        rpcUrl,
+        token
       });
+
+      const txHash = await this.transaction.sendTransaction(txParams);
 
       recipientInput.value = '';
       amountInput.value = '';
@@ -103,11 +107,96 @@ export class TransactionSendController {
           await sendTransaction();
         } catch (retryError) {
           console.error('[TransactionSendController] 重试发送失败:', retryError);
-          showError('发送失败: ' + retryError.message);
+          showError(this.formatTransactionError(retryError));
         }
         return;
       }
-      showError('发送失败: ' + error.message);
+      showError(this.formatTransactionError(error));
     }
   }
+
+  buildTransactionParams({ from, recipient, amount, chainId, rpcUrl, token }) {
+    if (!token || token.isNative) {
+      return {
+        from,
+        to: recipient,
+        value: this.transaction.parseEther(amount),
+        chainId,
+        rpcUrl
+      };
+    }
+
+    const tokenAddress = token.address;
+    if (!tokenAddress || !isValidAddress(tokenAddress)) {
+      throw new Error('通证合约地址无效');
+    }
+
+    const decimals = Number.isFinite(Number(token.decimals)) ? Number(token.decimals) : 18;
+    const valueHex = this.transaction.parseUnits(amount, decimals, token.symbol || '通证');
+
+    return {
+      from,
+      to: tokenAddress,
+      value: '0x0',
+      data: encodeErc20Transfer(recipient, valueHex),
+      chainId,
+      rpcUrl,
+      token: {
+        address: tokenAddress,
+        symbol: token.symbol || '',
+        name: token.name || token.symbol || '',
+        decimals,
+        amount: valueHex,
+        recipient
+      }
+    };
+  }
+
+  formatTransactionError(error) {
+    const rawMessage = String(error?.reason || error?.shortMessage || error?.message || error || '').trim();
+    const revertMessage = this.extractRevertMessage(rawMessage);
+    const message = revertMessage || rawMessage;
+    const normalized = message.toLowerCase();
+
+    if (normalized.includes('transfer amount exceeds balance')) {
+      return '发送失败: 通证余额不足';
+    }
+    if (normalized.includes('insufficient funds')) {
+      return '发送失败: 余额不足，无法支付金额或矿工费';
+    }
+    if (normalized.includes('user rejected') || normalized.includes('user denied')) {
+      return '发送失败: 用户已取消交易';
+    }
+    if (normalized.includes('execution reverted')) {
+      return `发送失败: ${message.replace(/^execution reverted:?\s*/i, '') || '交易被合约拒绝'}`;
+    }
+    if (normalized.includes('estimategas')) {
+      return '发送失败: 交易预估失败，请检查余额、授权或网络状态';
+    }
+
+    return `发送失败: ${message || '交易提交失败'}`;
+  }
+
+  extractRevertMessage(message) {
+    if (!message) return '';
+    const reasonMatch = message.match(/reason="([^"]+)"/);
+    if (reasonMatch?.[1]) {
+      return reasonMatch[1];
+    }
+    const revertedMatch = message.match(/execution reverted:\s*"([^"]+)"/i);
+    if (revertedMatch?.[1]) {
+      return revertedMatch[1];
+    }
+    const argsMatch = message.match(/"args":\s*\[\s*"([^"]+)"/);
+    if (argsMatch?.[1]) {
+      return argsMatch[1];
+    }
+    return '';
+  }
+}
+
+function encodeErc20Transfer(recipient, amountHex) {
+  const addressData = recipient.toLowerCase().replace(/^0x/, '').padStart(64, '0');
+  const amountData = BigInt(amountHex).toString(16).padStart(64, '0');
+  return `${ERC20_TRANSFER_SELECTOR}${addressData}${amountData}`;
 }

--- a/js/controller/transaction/transaction-send-controller.js
+++ b/js/controller/transaction/transaction-send-controller.js
@@ -11,6 +11,8 @@ export class TransactionSendController {
     this.network = network;
     this.balanceController = balanceController || null;
     this.transactionListController = transactionListController || null;
+    this.feeEstimateTimer = null;
+    this.feeEstimateSeq = 0;
   }
 
   setBalanceController(controller) {
@@ -115,6 +117,113 @@ export class TransactionSendController {
     }
   }
 
+  scheduleFeeEstimate(token = null) {
+    if (this.feeEstimateTimer) {
+      clearTimeout(this.feeEstimateTimer);
+    }
+    this.feeEstimateTimer = setTimeout(() => {
+      void this.updateFeeEstimate(token);
+    }, 350);
+  }
+
+  async updateFeeEstimate(token = null) {
+    const seq = ++this.feeEstimateSeq;
+    const recipientInput = document.getElementById('recipientAddress');
+    const amountInput = document.getElementById('amount');
+    const recipient = recipientInput?.value.trim();
+    const amount = amountInput?.value;
+
+    if (!recipient || !isValidAddress(recipient) || !amount || Number(amount) <= 0) {
+      this.setFeeEstimateText('-');
+      return;
+    }
+    this.setFeeEstimateText('预估中...');
+
+    try {
+      const account = await this.wallet.getCurrentAccount();
+      if (!account) {
+        this.setFeeEstimateText('-');
+        return;
+      }
+      const chainId = await this.network.getChainId();
+      const rpcUrl = await this.network.getRpcUrl();
+      const txParams = this.buildTransactionParams({
+        from: account.address,
+        recipient,
+        amount,
+        chainId,
+        rpcUrl,
+        token
+      });
+
+      const [gasHex, gasPriceHex] = await Promise.all([
+        this.transaction.estimateGas(txParams),
+        this.transaction.getGasPrice({
+          chainId,
+          rpcUrl
+        })
+      ]);
+      if (seq !== this.feeEstimateSeq) {
+        return;
+      }
+      this.setFeeEstimateText(this.formatFeeEstimate(gasHex, gasPriceHex));
+    } catch (error) {
+      if (seq !== this.feeEstimateSeq) {
+        return;
+      }
+      this.setFeeEstimateText(this.formatFeeEstimateError(error));
+    }
+  }
+
+  setFeeEstimateText(text) {
+    const el = document.getElementById('transferFeeEstimate');
+    if (el) {
+      el.textContent = text || '-';
+    }
+  }
+
+  formatFeeEstimate(gasHex, gasPriceHex) {
+    try {
+      const gas = BigInt(gasHex);
+      const gasPrice = BigInt(gasPriceHex);
+      const feeWei = gas * gasPrice;
+      const fee = this.transaction.formatEther(`0x${feeWei.toString(16)}`);
+      return `${fee} ETH`;
+    } catch {
+      return '-';
+    }
+  }
+
+  formatFeeEstimateError(error) {
+    const rawMessage = this.getErrorMessage(error);
+    const revertMessage = this.extractRevertMessage(rawMessage);
+    const message = revertMessage || rawMessage;
+    const normalized = message.toLowerCase();
+
+    if (normalized.includes('transfer amount exceeds balance')) {
+      return '通证余额不足';
+    }
+    if (normalized.includes('insufficient funds')) {
+      return '余额不足';
+    }
+    if (normalized.includes('user rejected') || normalized.includes('user denied')) {
+      return '用户已取消';
+    }
+    if (this.isNetworkEstimateError(normalized)) {
+      return 'RPC 不可用';
+    }
+    if (normalized.includes('execution reverted')) {
+      const reason = this.sanitizeShortError(message.replace(/^execution reverted:?\s*/i, ''));
+      return reason ? `交易会失败: ${reason}` : '交易会失败';
+    }
+    if (revertMessage) {
+      return `交易会失败: ${this.sanitizeShortError(revertMessage)}`;
+    }
+
+    const shortMessage = this.sanitizeShortError(message);
+    return shortMessage ? `预估失败: ${shortMessage}` : '预估失败';
+  }
+
   buildTransactionParams({ from, recipient, amount, chainId, rpcUrl, token }) {
     if (!token || token.isNative) {
       return {
@@ -153,7 +262,7 @@ export class TransactionSendController {
   }
 
   formatTransactionError(error) {
-    const rawMessage = String(error?.reason || error?.shortMessage || error?.message || error || '').trim();
+    const rawMessage = this.getErrorMessage(error);
     const revertMessage = this.extractRevertMessage(rawMessage);
     const message = revertMessage || rawMessage;
     const normalized = message.toLowerCase();
@@ -175,6 +284,39 @@ export class TransactionSendController {
     }
 
     return `发送失败: ${message || '交易提交失败'}`;
+  }
+
+  getErrorMessage(error) {
+    return String(error?.reason || error?.shortMessage || error?.message || error || '').trim();
+  }
+
+  isNetworkEstimateError(normalizedMessage) {
+    return normalizedMessage.includes('rpc url not configured')
+      || normalizedMessage.includes('failed to fetch')
+      || normalizedMessage.includes('network')
+      || normalizedMessage.includes('timeout')
+      || normalizedMessage.includes('http ')
+      || normalizedMessage.includes('rpc error')
+      || normalizedMessage.includes('disconnected')
+      || normalizedMessage.includes('could not establish connection')
+      || normalizedMessage.includes('message port closed')
+      || normalizedMessage.includes('receiving end does not exist');
+  }
+
+  sanitizeShortError(message) {
+    const cleaned = String(message || '')
+      .replace(/\s*\(action=.*$/i, '')
+      .replace(/\s*\{.*$/s, '')
+      .replace(/^error:\s*/i, '')
+      .replace(/^estimate gas failed:?\s*/i, '')
+      .replace(/^交易预估失败[:：]?\s*/i, '')
+      .trim();
+
+    if (!cleaned || cleaned === '[object Object]') {
+      return '';
+    }
+
+    return cleaned.length > 48 ? `${cleaned.slice(0, 48)}...` : cleaned;
   }
 
   extractRevertMessage(message) {

--- a/js/domain/transaction-domain.js
+++ b/js/domain/transaction-domain.js
@@ -228,10 +228,11 @@ export class TransactionDomain extends BaseDomain {
 
   /**
    * 获取当前 Gas 价格
+   * @param {Object} params - 网络参数
    * @returns {Promise<string>} 当前 Gas 价格（十六进制）
    */
-  async getGasPrice() {
-    const result = await this._sendMessage(TransactionMessageType.GET_GAS_PRICE);
+  async getGasPrice(params = {}) {
+    const result = await this._sendMessage(TransactionMessageType.GET_GAS_PRICE, params);
     return result.gasPrice;
   }
 

--- a/js/domain/transaction-domain.js
+++ b/js/domain/transaction-domain.js
@@ -29,13 +29,40 @@ export class TransactionDomain extends BaseDomain {
    * @returns {string} Wei 数量（十六进制）
    */
   parseEther(ether) {
-    const value = typeof ether === 'string' ? parseFloat(ether) : ether;
-    if (isNaN(value) || value < 0) {
-      throw new Error('无效的 ETH 数量');
+    return this.parseUnits(ether, 18, 'ETH');
+  }
+
+  /**
+   * 代币数量转换为最小单位
+   * @param {string|number} amount - 数量
+   * @param {number} decimals - 小数位
+   * @param {string} label - 单位标签
+   * @returns {string} 最小单位（十六进制）
+   */
+  parseUnits(amount, decimals = 18, label = 'token') {
+    const raw = String(amount ?? '').trim();
+    const parsedDecimals = Number(decimals);
+    const decimalPlaces = Number.isInteger(parsedDecimals) && parsedDecimals >= 0 ? parsedDecimals : 18;
+    if (!raw || decimalPlaces < 0) {
+      throw new Error(`无效的 ${label} 数量`);
     }
-    // 转换为 Wei
-    const wei = BigInt(Math.floor(value * 1e18));
-    return '0x' + wei.toString(16);
+    if (!/^\d+(\.\d+)?$/.test(raw)) {
+      throw new Error(`无效的 ${label} 数量`);
+    }
+
+    const [integerPart, fractionPart = ''] = raw.split('.');
+    if (fractionPart.length > decimalPlaces) {
+      throw new Error(`${label} 最多支持 ${decimalPlaces} 位小数`);
+    }
+
+    const paddedFraction = fractionPart.padEnd(decimalPlaces, '0');
+    const integerValue = BigInt(integerPart || '0') * (10n ** BigInt(decimalPlaces));
+    const fractionValue = paddedFraction ? BigInt(paddedFraction) : 0n;
+    const value = integerValue + fractionValue;
+    if (value <= 0n) {
+      throw new Error(`无效的 ${label} 数量`);
+    }
+    return `0x${value.toString(16)}`;
   }
 
   /**
@@ -44,14 +71,32 @@ export class TransactionDomain extends BaseDomain {
    * @returns {string} ETH 数量
    */
   formatEther(wei) {
+    return this.formatUnits(wei, 18);
+  }
+
+  /**
+   * 最小单位转换为代币数量
+   * @param {string} value - 最小单位（十六进制或十进制）
+   * @param {number} decimals - 小数位
+   * @returns {string} 格式化数量
+   */
+  formatUnits(value, decimals = 18) {
     try {
-      if (wei === null || wei === undefined || wei === '') {
+      if (value === null || value === undefined || value === '') {
         return '0.000000';
       }
-      const normalized = typeof wei === 'string' ? wei.trim() : wei;
-      const weiBigInt = BigInt(normalized);
-      const ether = Number(weiBigInt) / 1e18;
-      return ether.toFixed(6);
+      const normalized = typeof value === 'string' ? value.trim() : value;
+      const raw = BigInt(normalized);
+      const decimalPlaces = Number.isInteger(Number(decimals)) && Number(decimals) >= 0 ? Number(decimals) : 18;
+      const base = 10n ** BigInt(decimalPlaces);
+      const integer = raw / base;
+      const fraction = raw % base;
+      if (decimalPlaces === 0) {
+        return integer.toString();
+      }
+      const fractionText = fraction.toString().padStart(decimalPlaces, '0').slice(0, 6);
+      const formatted = `${integer}.${fractionText}`.replace(/\.?0+$/, '');
+      return formatted || '0';
     } catch (error) {
       return '0.000000';
     }
@@ -86,7 +131,7 @@ export class TransactionDomain extends BaseDomain {
    * @returns {Promise<string>} 交易哈希
    */
   async sendTransaction(txParams) {
-    const { from, to, value, data, gas, chainId, rpcUrl } = txParams;
+    const { from, to, value, data, gas, chainId, rpcUrl, token } = txParams;
 
     // 参数验证
     if (!from || !isValidAddress(from)) {
@@ -108,7 +153,8 @@ export class TransactionDomain extends BaseDomain {
       data: data || '0x',
       gas: gas || undefined,
       chainId,
-      rpcUrl
+      rpcUrl,
+      token: token || null
     });
 
     // 添加到交易记录
@@ -117,6 +163,7 @@ export class TransactionDomain extends BaseDomain {
       from,
       to,
       value,
+      token: token || null,
       timestamp: getTimestamp(),
       status: 'pending',
       chainId: chainId || null

--- a/js/storage/network-storage.js
+++ b/js/storage/network-storage.js
@@ -142,11 +142,13 @@ export async function ensureDefaultNetworks(defaults) {
       }
     }
 
-    if (!merged || merged.length === 0) {
-      merged = Object.entries(defaults || {}).map(([key, network]) => ({
-        ...network,
-        key
-      }));
+    const defaultNetworks = Object.entries(defaults || {}).map(([key, network]) => ({
+      ...network,
+      key
+    }));
+    const mergedDefaults = mergeNetworks(merged, defaultNetworks);
+    if (mergedDefaults.length !== merged.length) {
+      merged = mergedDefaults;
       changed = true;
     }
 


### PR DESCRIPTION
## Summary
- add Ethereum mainnet support with built-in USDC and USDT tokens
- support ERC-20 transfer construction and token transaction display
- add transfer fee estimates with concise failure reasons for balance, RPC, and contract revert errors

## Tests
- node --input-type=module -e "await import('./js/controller/transaction/transaction-send-controller.js'); await import('./js/domain/transaction-domain.js'); await import('./js/background/message-handler.js'); console.log('imports ok')"
- node --experimental-vm-modules scripts/test-approval-flow.mjs
- git diff --check