### PR TITLE
Bump extension version to 1.4.14

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "夜莺钱包",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "description": "夜莺钱包插件",
   "permissions": [
     "storage",


### PR DESCRIPTION
## Summary
- bump extension manifest version from 1.4.13 to 1.4.14

## Tests
- not run; manifest version-only change