### PR TITLE
fix import form secret cleanup

### DIFF
--- a/js/common/crypto/crypto-utils.js
+++ b/js/common/crypto/crypto-utils.js
@@ -109,7 +109,13 @@ export function bytesToString(bytes) {
  */
 export function base64Encode(bytes) {
   try {
-    return btoa(String.fromCharCode(...bytes));
+    const chunkSize = 0x8000;
+    let binary = '';
+    for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+      const chunk = bytes.subarray(offset, offset + chunkSize);
+      binary += String.fromCharCode(...chunk);
+    }
+    return btoa(binary);
   } catch (error) {
     logError('crypto-base64-encode', error);
     throw createCryptoError('Failed to encode base64');

--- a/js/controller/account/account-list-controller.js
+++ b/js/controller/account/account-list-controller.js
@@ -1,5 +1,6 @@
 import { showPage, showError, setPageOrigin, showWaiting, hideWaiting } from '../../common/ui/index.js';
 import { shortenAddress, generateAvatar } from '../../common/chain/index.js';
+import { clearImportWalletForm } from '../wallet/import-wallet-controller.js';
 
 export class AccountListController {
   constructor({
@@ -102,6 +103,7 @@ export class AccountListController {
     if (passwordInput) {
       passwordInput.placeholder = '输入当前密码';
     }
+    clearImportWalletForm();
   }
 
   async loadWalletList() {

--- a/js/controller/wallet/import-wallet-controller.js
+++ b/js/controller/wallet/import-wallet-controller.js
@@ -1,5 +1,36 @@
 import { showPage, showError, showSuccess, showWaiting, getPageOrigin } from '../../common/ui/index.js';
 
+const IMPORT_FIELD_IDS = [
+  'importAccountName',
+  'importMnemonic',
+  'importPrivateKey',
+  'importWalletPassword'
+];
+
+export function clearImportWalletForm({ resetType = true } = {}) {
+  IMPORT_FIELD_IDS.forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.value = '';
+    }
+  });
+
+  if (!resetType) {
+    return;
+  }
+
+  const tabs = Array.from(document.querySelectorAll('.import-tab'));
+  const mnemonicTab = tabs.find((tab) => tab?.dataset?.type === 'mnemonic');
+  const privateKeyTab = tabs.find((tab) => tab?.dataset?.type === 'privateKey');
+  const mnemonicSection = document.getElementById('mnemonicImportSection');
+  const privateKeySection = document.getElementById('privateKeyImportSection');
+
+  mnemonicTab?.classList.add('active');
+  privateKeyTab?.classList.remove('active');
+  mnemonicSection?.classList.remove('hidden');
+  privateKeySection?.classList.add('hidden');
+}
+
 export class ImportWalletController {
   constructor({ wallet, onImportSuccess }) {
     this.wallet = wallet;
@@ -86,6 +117,7 @@ export class ImportWalletController {
       }
 
       showSuccess('导入成功！');
+      clearImportWalletForm();
 
       setTimeout(() => {
         showPage('walletPage');
@@ -100,6 +132,7 @@ export class ImportWalletController {
 
   handleCancel() {
     const origin = getPageOrigin('importPage', 'welcome');
+    clearImportWalletForm();
     if (origin === 'accounts') {
       showPage('accountsPage');
       return;

--- a/js/controller/welcome-controller.js
+++ b/js/controller/welcome-controller.js
@@ -1,4 +1,5 @@
 import { showPage, setPageOrigin } from '../common/ui/index.js';
+import { clearImportWalletForm } from './wallet/import-wallet-controller.js';
 
 export class WelcomeController {
   constructor() {}
@@ -79,6 +80,7 @@ export class WelcomeController {
     if (passwordInput) {
       passwordInput.placeholder = '至少8位字符';
     }
+    clearImportWalletForm();
   }
 
   resetCreateWalletForm() {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "夜莺钱包",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "description": "夜莺钱包插件",
   "permissions": [
     "storage",

--- a/tests/crypto-utils.test.mjs
+++ b/tests/crypto-utils.test.mjs
@@ -88,6 +88,18 @@ test('base64Encode / base64Decode 往返', () => {
   assert.deepEqual([...base64Decode(b64)], [0, 1, 2, 254, 255]);
 });
 
+test('base64Encode：大字节数组分块编码，避免参数数量上限', () => {
+  const bytes = new Uint8Array(256 * 1024);
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = i & 0xff;
+  }
+  const b64 = base64Encode(bytes);
+  const restored = base64Decode(b64);
+  assert.equal(restored.length, bytes.length);
+  assert.deepEqual([...restored.slice(0, 512)], [...bytes.slice(0, 512)]);
+  assert.deepEqual([...restored.slice(-512)], [...bytes.slice(-512)]);
+});
+
 test('base64：经 string→bytes→base64→bytes→string 全链路', () => {
   const text = '助记词 mnemonic';
   const restored = bytesToString(base64Decode(base64Encode(stringToBytes(text))));

--- a/tests/import-wallet-controller.test.mjs
+++ b/tests/import-wallet-controller.test.mjs
@@ -1,0 +1,104 @@
+/**
+ * ImportWalletController DOM tests.
+ * 运行：npm test
+ *
+ * 覆盖导入页复用时的敏感字段清理，避免助记词/私钥/密码在不同入口之间残留。
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createDocument } from './_helpers/dom-stub.js';
+import { setPageOrigin } from '../js/common/ui/index.js';
+import { clearImportWalletForm, ImportWalletController } from '../js/controller/wallet/import-wallet-controller.js';
+import { WelcomeController } from '../js/controller/welcome-controller.js';
+import { AccountListController } from '../js/controller/account/account-list-controller.js';
+
+let elements;
+
+function setupDom() {
+  const doc = createDocument({
+    importPage: { tagName: 'div' },
+    welcomePage: { tagName: 'div' },
+    accountsPage: { tagName: 'div' },
+    walletPage: { tagName: 'div' },
+    importAccountName: { tagName: 'input' },
+    importMnemonic: { tagName: 'textarea' },
+    importPrivateKey: { tagName: 'input' },
+    importWalletPassword: { tagName: 'input' },
+    importPasswordLabel: { tagName: 'label' },
+    mnemonicImportSection: { tagName: 'div' },
+    privateKeyImportSection: { tagName: 'div' },
+    importBtn: { tagName: 'button' },
+    cancelImportBtn: { tagName: 'button' },
+    welcomeImportWalletBtn: { tagName: 'button' },
+    accountsImportWalletBtn: { tagName: 'button' },
+    mnemonicTab: { tagName: 'button', _classes: 'import-tab active', dataset: { type: 'mnemonic' } },
+    privateKeyTab: { tagName: 'button', _classes: 'import-tab', dataset: { type: 'privateKey' } }
+  });
+  elements = doc.elements;
+
+  globalThis.document = doc.document;
+  globalThis.window = globalThis.window || {};
+}
+
+function teardown() {
+  delete globalThis.document;
+  delete globalThis.window;
+}
+
+test.beforeEach(() => setupDom());
+test.afterEach(() => teardown());
+
+function fillImportSecrets() {
+  elements.importAccountName.value = 'leaked name';
+  elements.importMnemonic.value = 'test test test test test test test test test test test junk';
+  elements.importPrivateKey.value = '0xabc';
+  elements.importWalletPassword.value = 'Secret-Pass-123';
+  elements.privateKeyTab.classList.add('active');
+  elements.mnemonicTab.classList.remove('active');
+  elements.mnemonicImportSection.classList.add('hidden');
+  elements.privateKeyImportSection.classList.remove('hidden');
+}
+
+function assertImportFormCleared() {
+  assert.equal(elements.importAccountName.value, '');
+  assert.equal(elements.importMnemonic.value, '');
+  assert.equal(elements.importPrivateKey.value, '');
+  assert.equal(elements.importWalletPassword.value, '');
+  assert.ok(elements.mnemonicTab.classList.contains('active'));
+  assert.ok(!elements.privateKeyTab.classList.contains('active'));
+  assert.ok(!elements.mnemonicImportSection.classList.contains('hidden'));
+  assert.ok(elements.privateKeyImportSection.classList.contains('hidden'));
+}
+
+test('clearImportWalletForm：清空助记词/私钥/密码并重置到助记词页签', () => {
+  fillImportSecrets();
+  clearImportWalletForm();
+  assertImportFormCleared();
+});
+
+test('首次导入入口：打开导入页前清空上次残留的敏感输入', () => {
+  fillImportSecrets();
+  const c = new WelcomeController();
+  c.prepareImportFormForNewWallet();
+  assert.equal(elements.importPasswordLabel.textContent, '密码');
+  assert.equal(elements.importWalletPassword.placeholder, '至少8位字符');
+  assertImportFormCleared();
+});
+
+test('账户管理导入入口：打开导入页前清空首次导入残留的敏感输入', () => {
+  fillImportSecrets();
+  const c = new AccountListController({ wallet: {} });
+  c.prepareImportFormForExistingWallet();
+  assert.equal(elements.importPasswordLabel.textContent, '当前密码');
+  assert.equal(elements.importWalletPassword.placeholder, '输入当前密码');
+  assertImportFormCleared();
+});
+
+test('取消导入：离开导入页时清空敏感输入', () => {
+  fillImportSecrets();
+  setPageOrigin('importPage', 'accounts');
+  const c = new ImportWalletController({ wallet: {} });
+  c.handleCancel();
+  assertImportFormCleared();
+});


### PR DESCRIPTION
## Summary
- clear mnemonic/private-key/password fields when reusing the import wallet page
- reset import form tab state on entry, cancel, and successful import
- make base64 encoding handle large byte arrays safely

## Tests
- node --test --test-force-exit tests/import-wallet-controller.test.mjs
- node --test --test-force-exit --test-isolation=none tests/change-password-edges.test.mjs